### PR TITLE
Modelados EF, Enums, APIs, 

### DIFF
--- a/Lumina-Backend/Controllers/RegistrationController.cs
+++ b/Lumina-Backend/Controllers/RegistrationController.cs
@@ -2,6 +2,7 @@
 using Lumina_Backend.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System.Reflection;
 using static Lumina_Backend.Models.BaseEntity;
 
 namespace Lumina_Backend.Controllers;

--- a/Lumina-Backend/Migrations/20240416161218_Base.Designer.cs
+++ b/Lumina-Backend/Migrations/20240416161218_Base.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Lumina_Backend.Migrations
 {
     [DbContext(typeof(ApiDbContext))]
-    [Migration("20240416093149_Base")]
+    [Migration("20240416161218_Base")]
     partial class Base
     {
         /// <inheritdoc />
@@ -45,11 +45,13 @@ namespace Lumina_Backend.Migrations
                     b.Property<DateTime>("DateUpdated")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<int>("Status")
-                        .HasColumnType("integer");
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasColumnType("varchar(24)");
 
-                    b.Property<int>("Type")
-                        .HasColumnType("integer");
+                    b.Property<string>("Type")
+                        .IsRequired()
+                        .HasColumnType("varchar(24)");
 
                     b.Property<int>("UserId")
                         .HasColumnType("integer");
@@ -69,17 +71,16 @@ namespace Lumina_Backend.Migrations
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
-                    b.Property<int>("Action")
-                        .HasColumnType("integer");
+                    b.Property<string>("Action")
+                        .IsRequired()
+                        .HasColumnType("varchar(24)");
 
-                    b.Property<DateTime>("DateAdded")
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasColumnType("varchar(24)");
+
+                    b.Property<DateTime>("Timestamp")
                         .HasColumnType("timestamp with time zone");
-
-                    b.Property<DateTime>("DateUpdated")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("Status")
-                        .HasColumnType("integer");
 
                     b.Property<int>("UserId")
                         .HasColumnType("integer");
@@ -113,8 +114,9 @@ namespace Lumina_Backend.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<int>("Status")
-                        .HasColumnType("integer");
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasColumnType("varchar(24)");
 
                     b.Property<int>("UserId")
                         .HasColumnType("integer");
@@ -146,14 +148,16 @@ namespace Lumina_Backend.Migrations
                     b.Property<DateTime>("DateUpdated")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<int>("Status")
-                        .HasColumnType("integer");
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasColumnType("varchar(24)");
 
                     b.Property<string>("TransactionDescription")
                         .HasColumnType("text");
 
-                    b.Property<int>("Type")
-                        .HasColumnType("integer");
+                    b.Property<string>("Type")
+                        .IsRequired()
+                        .HasColumnType("varchar(24)");
 
                     b.HasKey("Id");
 
@@ -202,8 +206,9 @@ namespace Lumina_Backend.Migrations
                     b.Property<string>("SessionToken")
                         .HasColumnType("text");
 
-                    b.Property<int>("Status")
-                        .HasColumnType("integer");
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasColumnType("varchar(24)");
 
                     b.Property<string>("UserName")
                         .IsRequired()
@@ -217,100 +222,100 @@ namespace Lumina_Backend.Migrations
                         new
                         {
                             Id = -1,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 48, 132, DateTimeKind.Utc).AddTicks(1033),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 48, 132, DateTimeKind.Utc).AddTicks(1037),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 17, 238, DateTimeKind.Utc).AddTicks(9687),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 17, 238, DateTimeKind.Utc).AddTicks(9690),
                             Email = "ajruiz2204@example.com",
                             FullName = "Alejandro Ruíz",
-                            Password = "$2a$11$IZ8Ml9S/F8.j4u5qgNfPJ.QXyglpTtUkmOVAfQipPWJ88rtcGFzOK",
-                            Status = 0,
+                            Password = "$2a$11$EwmJZ3iZZgJkhKfM/wLc.e0G3EXjRUV0MzNRyDHVSCoV1chrDACpm",
+                            Status = "Unverified",
                             UserName = "ajruiz2204"
                         },
                         new
                         {
                             Id = -2,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 48, 251, DateTimeKind.Utc).AddTicks(1892),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 48, 251, DateTimeKind.Utc).AddTicks(1898),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 17, 356, DateTimeKind.Utc).AddTicks(7186),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 17, 356, DateTimeKind.Utc).AddTicks(7191),
                             Email = "alexanderfrt@example.com",
                             FullName = "Alexander Flores",
-                            Password = "$2a$11$WqvaMnKjbYlgxyiIeG0NM.jLblU4er.zgJ2Ju74tn2XZmxd4o0rCi",
-                            Status = 0,
+                            Password = "$2a$11$8qWWfAnwnaEzP7cRjAHhNOo.w18W1D8uxcZRQzv63RpL9XI577ZrG",
+                            Status = "Unverified",
                             UserName = "AlexanderFRT"
                         },
                         new
                         {
                             Id = -3,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 48, 375, DateTimeKind.Utc).AddTicks(7530),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 48, 375, DateTimeKind.Utc).AddTicks(7534),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 17, 478, DateTimeKind.Utc).AddTicks(5811),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 17, 478, DateTimeKind.Utc).AddTicks(5815),
                             Email = "4rnol@example.com",
                             FullName = "Arnol Flores",
-                            Password = "$2a$11$T0hvx6cDyDj/97QHq7ZPheWKEy22VFA1EclxcMQqXICsehWUulPzy",
-                            Status = 0,
+                            Password = "$2a$11$m7/EMJzEZCIY4YYO6jM4SevLJ0/wGE9YYQl2V09Q2afh/5QnTxFL2",
+                            Status = "Unverified",
                             UserName = "4rnol"
                         },
                         new
                         {
                             Id = -4,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 48, 501, DateTimeKind.Utc).AddTicks(6184),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 48, 501, DateTimeKind.Utc).AddTicks(6188),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 17, 601, DateTimeKind.Utc).AddTicks(3024),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 17, 601, DateTimeKind.Utc).AddTicks(3028),
                             Email = "ema_ramirez@example.com",
                             FullName = "Emanuel Ramirez",
-                            Password = "$2a$11$fJpIxRGPBg004nFlJ6VeU.Z5GTzCrsbc7hlKponpEjoE9e9OQtAj2",
-                            Status = 0,
+                            Password = "$2a$11$DRxNIeJzHlvwlciYDRAXo.NqU4f5PcqknodrvsTBV3.GTIedZU35i",
+                            Status = "Unverified",
                             UserName = "ema_ramirez"
                         },
                         new
                         {
                             Id = -5,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 48, 622, DateTimeKind.Utc).AddTicks(6799),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 48, 622, DateTimeKind.Utc).AddTicks(6804),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 17, 720, DateTimeKind.Utc).AddTicks(8451),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 17, 720, DateTimeKind.Utc).AddTicks(8456),
                             Email = "ezealeguzman@example.com",
                             FullName = "Ezequiel Guzman",
-                            Password = "$2a$11$V4bLjiCzzhpShjgWMBfji.a87BdvrSXSWvxNnTdGRZeVNn0iR187a",
-                            Status = 0,
+                            Password = "$2a$11$3yS42NIMEOxCajtvP9DM/.Cg.otrj/uCnqE/Y2ZitBS2pa6fHzaRa",
+                            Status = "Unverified",
                             UserName = "ezealeguzman"
                         },
                         new
                         {
                             Id = -6,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 48, 741, DateTimeKind.Utc).AddTicks(3982),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 48, 741, DateTimeKind.Utc).AddTicks(3988),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 17, 843, DateTimeKind.Utc).AddTicks(1194),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 17, 843, DateTimeKind.Utc).AddTicks(1199),
                             Email = "facu597@example.com",
                             FullName = "Facundo Castro",
-                            Password = "$2a$11$SyZnLRF2HIwXX7gbzfChbes3w3M4id5bL1AQUf.TFHTEOacPuWMnW",
-                            Status = 0,
+                            Password = "$2a$11$b4SKB9OtwM3mEogZ3HFeEOiNciNFgwHsE5Y.DOEdGva2OZa9CFopS",
+                            Status = "Unverified",
                             UserName = "facu597"
                         },
                         new
                         {
                             Id = -7,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 48, 861, DateTimeKind.Utc).AddTicks(9994),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 48, 862, DateTimeKind.Utc).AddTicks(31),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 17, 961, DateTimeKind.Utc).AddTicks(2858),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 17, 961, DateTimeKind.Utc).AddTicks(2862),
                             Email = "giolucc@example.com",
                             FullName = "Giovanni Lucchetta",
-                            Password = "$2a$11$ZXH5ERbRJ8g9EuzePTc5u../9it.Uk2Dymm3HdtZKujnL3Em.SNTK",
-                            Status = 0,
+                            Password = "$2a$11$d6WywWN3LwUjybHsdkTnnOA/VbCskFoEz3jHvCoYZnN5QyhvtyuP2",
+                            Status = "Unverified",
                             UserName = "giolucc"
                         },
                         new
                         {
                             Id = -8,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 48, 981, DateTimeKind.Utc).AddTicks(4724),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 48, 981, DateTimeKind.Utc).AddTicks(4728),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 18, 83, DateTimeKind.Utc).AddTicks(3648),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 18, 83, DateTimeKind.Utc).AddTicks(3651),
                             Email = "karla6524@example.com",
                             FullName = "Karla Chavez",
-                            Password = "$2a$11$m9Xwd4.i75APLKWj7eYfh.4nT2noIQ.v5RUH62eyrjoT/qFa81QZa",
-                            Status = 0,
+                            Password = "$2a$11$4AXjRfgLoNQZ2cYimg/aRu/NcCbJwMoN51w5LDr9On/L40gw.NFFK",
+                            Status = "Unverified",
                             UserName = "karla6524"
                         },
                         new
                         {
                             Id = -9,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 49, 100, DateTimeKind.Utc).AddTicks(245),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 49, 100, DateTimeKind.Utc).AddTicks(250),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 18, 202, DateTimeKind.Utc).AddTicks(3793),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 18, 202, DateTimeKind.Utc).AddTicks(3797),
                             Email = "mabel8750_@example.com",
                             FullName = "Mabel Ceballos",
-                            Password = "$2a$11$0.9MoZTHNFENbwkQSvUKEu8pYhiEjlskgOwRyX1p0icPGB/qA6ZsO",
-                            Status = 0,
+                            Password = "$2a$11$b9Yj0oFU037ZnFzkgzdNHe9WzMMTEcdesj0NnUMJWrjVWzy1cKF8W",
+                            Status = "Unverified",
                             UserName = "mabel8750_"
                         });
                 });

--- a/Lumina-Backend/Migrations/20240416161218_Base.cs
+++ b/Lumina-Backend/Migrations/20240416161218_Base.cs
@@ -29,7 +29,7 @@ namespace Lumina_Backend.Migrations
                     Address = table.Column<string>(type: "text", nullable: true),
                     DNI = table.Column<string>(type: "text", nullable: true),
                     ProfileImage = table.Column<string>(type: "text", nullable: true),
-                    Status = table.Column<int>(type: "integer", nullable: false),
+                    Status = table.Column<string>(type: "varchar(24)", nullable: false),
                     DateAdded = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
                     DateUpdated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
                 },
@@ -46,9 +46,9 @@ namespace Lumina_Backend.Migrations
                         .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
                     UserId = table.Column<int>(type: "integer", nullable: false),
                     AccountNumber = table.Column<int>(type: "integer", nullable: false),
-                    Type = table.Column<int>(type: "integer", nullable: false),
+                    Type = table.Column<string>(type: "varchar(24)", nullable: false),
                     Balance = table.Column<decimal>(type: "numeric", nullable: false),
-                    Status = table.Column<int>(type: "integer", nullable: false),
+                    Status = table.Column<string>(type: "varchar(24)", nullable: false),
                     DateAdded = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
                     DateUpdated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
                 },
@@ -70,10 +70,9 @@ namespace Lumina_Backend.Migrations
                     Id = table.Column<int>(type: "integer", nullable: false)
                         .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
                     UserId = table.Column<int>(type: "integer", nullable: false),
-                    Action = table.Column<int>(type: "integer", nullable: false),
-                    Status = table.Column<int>(type: "integer", nullable: false),
-                    DateAdded = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
-                    DateUpdated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                    Action = table.Column<string>(type: "varchar(24)", nullable: false),
+                    Status = table.Column<string>(type: "varchar(24)", nullable: false),
+                    Timestamp = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -95,7 +94,7 @@ namespace Lumina_Backend.Migrations
                     UserId = table.Column<int>(type: "integer", nullable: false),
                     SecurityQuestion = table.Column<string>(type: "text", nullable: false),
                     SecurityAnswer = table.Column<string>(type: "text", nullable: false),
-                    Status = table.Column<int>(type: "integer", nullable: false),
+                    Status = table.Column<string>(type: "varchar(24)", nullable: false),
                     DateAdded = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
                     DateUpdated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
                 },
@@ -117,10 +116,10 @@ namespace Lumina_Backend.Migrations
                     Id = table.Column<int>(type: "integer", nullable: false)
                         .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
                     AccountNumber = table.Column<int>(type: "integer", nullable: false),
-                    Type = table.Column<int>(type: "integer", nullable: false),
+                    Type = table.Column<string>(type: "varchar(24)", nullable: false),
                     Amount = table.Column<decimal>(type: "numeric", nullable: false),
                     TransactionDescription = table.Column<string>(type: "text", nullable: true),
-                    Status = table.Column<int>(type: "integer", nullable: false),
+                    Status = table.Column<string>(type: "varchar(24)", nullable: false),
                     DateAdded = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
                     DateUpdated = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
                 },
@@ -140,15 +139,15 @@ namespace Lumina_Backend.Migrations
                 columns: new[] { "Id", "Address", "DNI", "DateAdded", "DateOfBirth", "DateUpdated", "Email", "FullName", "Password", "ProfileImage", "SessionToken", "Status", "UserName" },
                 values: new object[,]
                 {
-                    { -9, null, null, new DateTime(2024, 4, 16, 9, 31, 49, 100, DateTimeKind.Utc).AddTicks(245), null, new DateTime(2024, 4, 16, 9, 31, 49, 100, DateTimeKind.Utc).AddTicks(250), "mabel8750_@example.com", "Mabel Ceballos", "$2a$11$0.9MoZTHNFENbwkQSvUKEu8pYhiEjlskgOwRyX1p0icPGB/qA6ZsO", null, null, 0, "mabel8750_" },
-                    { -8, null, null, new DateTime(2024, 4, 16, 9, 31, 48, 981, DateTimeKind.Utc).AddTicks(4724), null, new DateTime(2024, 4, 16, 9, 31, 48, 981, DateTimeKind.Utc).AddTicks(4728), "karla6524@example.com", "Karla Chavez", "$2a$11$m9Xwd4.i75APLKWj7eYfh.4nT2noIQ.v5RUH62eyrjoT/qFa81QZa", null, null, 0, "karla6524" },
-                    { -7, null, null, new DateTime(2024, 4, 16, 9, 31, 48, 861, DateTimeKind.Utc).AddTicks(9994), null, new DateTime(2024, 4, 16, 9, 31, 48, 862, DateTimeKind.Utc).AddTicks(31), "giolucc@example.com", "Giovanni Lucchetta", "$2a$11$ZXH5ERbRJ8g9EuzePTc5u../9it.Uk2Dymm3HdtZKujnL3Em.SNTK", null, null, 0, "giolucc" },
-                    { -6, null, null, new DateTime(2024, 4, 16, 9, 31, 48, 741, DateTimeKind.Utc).AddTicks(3982), null, new DateTime(2024, 4, 16, 9, 31, 48, 741, DateTimeKind.Utc).AddTicks(3988), "facu597@example.com", "Facundo Castro", "$2a$11$SyZnLRF2HIwXX7gbzfChbes3w3M4id5bL1AQUf.TFHTEOacPuWMnW", null, null, 0, "facu597" },
-                    { -5, null, null, new DateTime(2024, 4, 16, 9, 31, 48, 622, DateTimeKind.Utc).AddTicks(6799), null, new DateTime(2024, 4, 16, 9, 31, 48, 622, DateTimeKind.Utc).AddTicks(6804), "ezealeguzman@example.com", "Ezequiel Guzman", "$2a$11$V4bLjiCzzhpShjgWMBfji.a87BdvrSXSWvxNnTdGRZeVNn0iR187a", null, null, 0, "ezealeguzman" },
-                    { -4, null, null, new DateTime(2024, 4, 16, 9, 31, 48, 501, DateTimeKind.Utc).AddTicks(6184), null, new DateTime(2024, 4, 16, 9, 31, 48, 501, DateTimeKind.Utc).AddTicks(6188), "ema_ramirez@example.com", "Emanuel Ramirez", "$2a$11$fJpIxRGPBg004nFlJ6VeU.Z5GTzCrsbc7hlKponpEjoE9e9OQtAj2", null, null, 0, "ema_ramirez" },
-                    { -3, null, null, new DateTime(2024, 4, 16, 9, 31, 48, 375, DateTimeKind.Utc).AddTicks(7530), null, new DateTime(2024, 4, 16, 9, 31, 48, 375, DateTimeKind.Utc).AddTicks(7534), "4rnol@example.com", "Arnol Flores", "$2a$11$T0hvx6cDyDj/97QHq7ZPheWKEy22VFA1EclxcMQqXICsehWUulPzy", null, null, 0, "4rnol" },
-                    { -2, null, null, new DateTime(2024, 4, 16, 9, 31, 48, 251, DateTimeKind.Utc).AddTicks(1892), null, new DateTime(2024, 4, 16, 9, 31, 48, 251, DateTimeKind.Utc).AddTicks(1898), "alexanderfrt@example.com", "Alexander Flores", "$2a$11$WqvaMnKjbYlgxyiIeG0NM.jLblU4er.zgJ2Ju74tn2XZmxd4o0rCi", null, null, 0, "AlexanderFRT" },
-                    { -1, null, null, new DateTime(2024, 4, 16, 9, 31, 48, 132, DateTimeKind.Utc).AddTicks(1033), null, new DateTime(2024, 4, 16, 9, 31, 48, 132, DateTimeKind.Utc).AddTicks(1037), "ajruiz2204@example.com", "Alejandro Ruíz", "$2a$11$IZ8Ml9S/F8.j4u5qgNfPJ.QXyglpTtUkmOVAfQipPWJ88rtcGFzOK", null, null, 0, "ajruiz2204" }
+                    { -9, null, null, new DateTime(2024, 4, 16, 16, 12, 18, 202, DateTimeKind.Utc).AddTicks(3793), null, new DateTime(2024, 4, 16, 16, 12, 18, 202, DateTimeKind.Utc).AddTicks(3797), "mabel8750_@example.com", "Mabel Ceballos", "$2a$11$b9Yj0oFU037ZnFzkgzdNHe9WzMMTEcdesj0NnUMJWrjVWzy1cKF8W", null, null, "Unverified", "mabel8750_" },
+                    { -8, null, null, new DateTime(2024, 4, 16, 16, 12, 18, 83, DateTimeKind.Utc).AddTicks(3648), null, new DateTime(2024, 4, 16, 16, 12, 18, 83, DateTimeKind.Utc).AddTicks(3651), "karla6524@example.com", "Karla Chavez", "$2a$11$4AXjRfgLoNQZ2cYimg/aRu/NcCbJwMoN51w5LDr9On/L40gw.NFFK", null, null, "Unverified", "karla6524" },
+                    { -7, null, null, new DateTime(2024, 4, 16, 16, 12, 17, 961, DateTimeKind.Utc).AddTicks(2858), null, new DateTime(2024, 4, 16, 16, 12, 17, 961, DateTimeKind.Utc).AddTicks(2862), "giolucc@example.com", "Giovanni Lucchetta", "$2a$11$d6WywWN3LwUjybHsdkTnnOA/VbCskFoEz3jHvCoYZnN5QyhvtyuP2", null, null, "Unverified", "giolucc" },
+                    { -6, null, null, new DateTime(2024, 4, 16, 16, 12, 17, 843, DateTimeKind.Utc).AddTicks(1194), null, new DateTime(2024, 4, 16, 16, 12, 17, 843, DateTimeKind.Utc).AddTicks(1199), "facu597@example.com", "Facundo Castro", "$2a$11$b4SKB9OtwM3mEogZ3HFeEOiNciNFgwHsE5Y.DOEdGva2OZa9CFopS", null, null, "Unverified", "facu597" },
+                    { -5, null, null, new DateTime(2024, 4, 16, 16, 12, 17, 720, DateTimeKind.Utc).AddTicks(8451), null, new DateTime(2024, 4, 16, 16, 12, 17, 720, DateTimeKind.Utc).AddTicks(8456), "ezealeguzman@example.com", "Ezequiel Guzman", "$2a$11$3yS42NIMEOxCajtvP9DM/.Cg.otrj/uCnqE/Y2ZitBS2pa6fHzaRa", null, null, "Unverified", "ezealeguzman" },
+                    { -4, null, null, new DateTime(2024, 4, 16, 16, 12, 17, 601, DateTimeKind.Utc).AddTicks(3024), null, new DateTime(2024, 4, 16, 16, 12, 17, 601, DateTimeKind.Utc).AddTicks(3028), "ema_ramirez@example.com", "Emanuel Ramirez", "$2a$11$DRxNIeJzHlvwlciYDRAXo.NqU4f5PcqknodrvsTBV3.GTIedZU35i", null, null, "Unverified", "ema_ramirez" },
+                    { -3, null, null, new DateTime(2024, 4, 16, 16, 12, 17, 478, DateTimeKind.Utc).AddTicks(5811), null, new DateTime(2024, 4, 16, 16, 12, 17, 478, DateTimeKind.Utc).AddTicks(5815), "4rnol@example.com", "Arnol Flores", "$2a$11$m7/EMJzEZCIY4YYO6jM4SevLJ0/wGE9YYQl2V09Q2afh/5QnTxFL2", null, null, "Unverified", "4rnol" },
+                    { -2, null, null, new DateTime(2024, 4, 16, 16, 12, 17, 356, DateTimeKind.Utc).AddTicks(7186), null, new DateTime(2024, 4, 16, 16, 12, 17, 356, DateTimeKind.Utc).AddTicks(7191), "alexanderfrt@example.com", "Alexander Flores", "$2a$11$8qWWfAnwnaEzP7cRjAHhNOo.w18W1D8uxcZRQzv63RpL9XI577ZrG", null, null, "Unverified", "AlexanderFRT" },
+                    { -1, null, null, new DateTime(2024, 4, 16, 16, 12, 17, 238, DateTimeKind.Utc).AddTicks(9687), null, new DateTime(2024, 4, 16, 16, 12, 17, 238, DateTimeKind.Utc).AddTicks(9690), "ajruiz2204@example.com", "Alejandro Ruíz", "$2a$11$EwmJZ3iZZgJkhKfM/wLc.e0G3EXjRUV0MzNRyDHVSCoV1chrDACpm", null, null, "Unverified", "ajruiz2204" }
                 });
 
             migrationBuilder.CreateIndex(

--- a/Lumina-Backend/Migrations/ApiDbContextModelSnapshot.cs
+++ b/Lumina-Backend/Migrations/ApiDbContextModelSnapshot.cs
@@ -42,11 +42,13 @@ namespace Lumina_Backend.Migrations
                     b.Property<DateTime>("DateUpdated")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<int>("Status")
-                        .HasColumnType("integer");
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasColumnType("varchar(24)");
 
-                    b.Property<int>("Type")
-                        .HasColumnType("integer");
+                    b.Property<string>("Type")
+                        .IsRequired()
+                        .HasColumnType("varchar(24)");
 
                     b.Property<int>("UserId")
                         .HasColumnType("integer");
@@ -66,17 +68,16 @@ namespace Lumina_Backend.Migrations
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
-                    b.Property<int>("Action")
-                        .HasColumnType("integer");
+                    b.Property<string>("Action")
+                        .IsRequired()
+                        .HasColumnType("varchar(24)");
 
-                    b.Property<DateTime>("DateAdded")
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasColumnType("varchar(24)");
+
+                    b.Property<DateTime>("Timestamp")
                         .HasColumnType("timestamp with time zone");
-
-                    b.Property<DateTime>("DateUpdated")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<int>("Status")
-                        .HasColumnType("integer");
 
                     b.Property<int>("UserId")
                         .HasColumnType("integer");
@@ -110,8 +111,9 @@ namespace Lumina_Backend.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<int>("Status")
-                        .HasColumnType("integer");
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasColumnType("varchar(24)");
 
                     b.Property<int>("UserId")
                         .HasColumnType("integer");
@@ -143,14 +145,16 @@ namespace Lumina_Backend.Migrations
                     b.Property<DateTime>("DateUpdated")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<int>("Status")
-                        .HasColumnType("integer");
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasColumnType("varchar(24)");
 
                     b.Property<string>("TransactionDescription")
                         .HasColumnType("text");
 
-                    b.Property<int>("Type")
-                        .HasColumnType("integer");
+                    b.Property<string>("Type")
+                        .IsRequired()
+                        .HasColumnType("varchar(24)");
 
                     b.HasKey("Id");
 
@@ -199,8 +203,9 @@ namespace Lumina_Backend.Migrations
                     b.Property<string>("SessionToken")
                         .HasColumnType("text");
 
-                    b.Property<int>("Status")
-                        .HasColumnType("integer");
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasColumnType("varchar(24)");
 
                     b.Property<string>("UserName")
                         .IsRequired()
@@ -214,100 +219,100 @@ namespace Lumina_Backend.Migrations
                         new
                         {
                             Id = -1,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 48, 132, DateTimeKind.Utc).AddTicks(1033),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 48, 132, DateTimeKind.Utc).AddTicks(1037),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 17, 238, DateTimeKind.Utc).AddTicks(9687),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 17, 238, DateTimeKind.Utc).AddTicks(9690),
                             Email = "ajruiz2204@example.com",
                             FullName = "Alejandro Ruíz",
-                            Password = "$2a$11$IZ8Ml9S/F8.j4u5qgNfPJ.QXyglpTtUkmOVAfQipPWJ88rtcGFzOK",
-                            Status = 0,
+                            Password = "$2a$11$EwmJZ3iZZgJkhKfM/wLc.e0G3EXjRUV0MzNRyDHVSCoV1chrDACpm",
+                            Status = "Unverified",
                             UserName = "ajruiz2204"
                         },
                         new
                         {
                             Id = -2,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 48, 251, DateTimeKind.Utc).AddTicks(1892),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 48, 251, DateTimeKind.Utc).AddTicks(1898),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 17, 356, DateTimeKind.Utc).AddTicks(7186),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 17, 356, DateTimeKind.Utc).AddTicks(7191),
                             Email = "alexanderfrt@example.com",
                             FullName = "Alexander Flores",
-                            Password = "$2a$11$WqvaMnKjbYlgxyiIeG0NM.jLblU4er.zgJ2Ju74tn2XZmxd4o0rCi",
-                            Status = 0,
+                            Password = "$2a$11$8qWWfAnwnaEzP7cRjAHhNOo.w18W1D8uxcZRQzv63RpL9XI577ZrG",
+                            Status = "Unverified",
                             UserName = "AlexanderFRT"
                         },
                         new
                         {
                             Id = -3,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 48, 375, DateTimeKind.Utc).AddTicks(7530),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 48, 375, DateTimeKind.Utc).AddTicks(7534),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 17, 478, DateTimeKind.Utc).AddTicks(5811),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 17, 478, DateTimeKind.Utc).AddTicks(5815),
                             Email = "4rnol@example.com",
                             FullName = "Arnol Flores",
-                            Password = "$2a$11$T0hvx6cDyDj/97QHq7ZPheWKEy22VFA1EclxcMQqXICsehWUulPzy",
-                            Status = 0,
+                            Password = "$2a$11$m7/EMJzEZCIY4YYO6jM4SevLJ0/wGE9YYQl2V09Q2afh/5QnTxFL2",
+                            Status = "Unverified",
                             UserName = "4rnol"
                         },
                         new
                         {
                             Id = -4,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 48, 501, DateTimeKind.Utc).AddTicks(6184),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 48, 501, DateTimeKind.Utc).AddTicks(6188),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 17, 601, DateTimeKind.Utc).AddTicks(3024),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 17, 601, DateTimeKind.Utc).AddTicks(3028),
                             Email = "ema_ramirez@example.com",
                             FullName = "Emanuel Ramirez",
-                            Password = "$2a$11$fJpIxRGPBg004nFlJ6VeU.Z5GTzCrsbc7hlKponpEjoE9e9OQtAj2",
-                            Status = 0,
+                            Password = "$2a$11$DRxNIeJzHlvwlciYDRAXo.NqU4f5PcqknodrvsTBV3.GTIedZU35i",
+                            Status = "Unverified",
                             UserName = "ema_ramirez"
                         },
                         new
                         {
                             Id = -5,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 48, 622, DateTimeKind.Utc).AddTicks(6799),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 48, 622, DateTimeKind.Utc).AddTicks(6804),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 17, 720, DateTimeKind.Utc).AddTicks(8451),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 17, 720, DateTimeKind.Utc).AddTicks(8456),
                             Email = "ezealeguzman@example.com",
                             FullName = "Ezequiel Guzman",
-                            Password = "$2a$11$V4bLjiCzzhpShjgWMBfji.a87BdvrSXSWvxNnTdGRZeVNn0iR187a",
-                            Status = 0,
+                            Password = "$2a$11$3yS42NIMEOxCajtvP9DM/.Cg.otrj/uCnqE/Y2ZitBS2pa6fHzaRa",
+                            Status = "Unverified",
                             UserName = "ezealeguzman"
                         },
                         new
                         {
                             Id = -6,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 48, 741, DateTimeKind.Utc).AddTicks(3982),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 48, 741, DateTimeKind.Utc).AddTicks(3988),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 17, 843, DateTimeKind.Utc).AddTicks(1194),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 17, 843, DateTimeKind.Utc).AddTicks(1199),
                             Email = "facu597@example.com",
                             FullName = "Facundo Castro",
-                            Password = "$2a$11$SyZnLRF2HIwXX7gbzfChbes3w3M4id5bL1AQUf.TFHTEOacPuWMnW",
-                            Status = 0,
+                            Password = "$2a$11$b4SKB9OtwM3mEogZ3HFeEOiNciNFgwHsE5Y.DOEdGva2OZa9CFopS",
+                            Status = "Unverified",
                             UserName = "facu597"
                         },
                         new
                         {
                             Id = -7,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 48, 861, DateTimeKind.Utc).AddTicks(9994),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 48, 862, DateTimeKind.Utc).AddTicks(31),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 17, 961, DateTimeKind.Utc).AddTicks(2858),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 17, 961, DateTimeKind.Utc).AddTicks(2862),
                             Email = "giolucc@example.com",
                             FullName = "Giovanni Lucchetta",
-                            Password = "$2a$11$ZXH5ERbRJ8g9EuzePTc5u../9it.Uk2Dymm3HdtZKujnL3Em.SNTK",
-                            Status = 0,
+                            Password = "$2a$11$d6WywWN3LwUjybHsdkTnnOA/VbCskFoEz3jHvCoYZnN5QyhvtyuP2",
+                            Status = "Unverified",
                             UserName = "giolucc"
                         },
                         new
                         {
                             Id = -8,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 48, 981, DateTimeKind.Utc).AddTicks(4724),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 48, 981, DateTimeKind.Utc).AddTicks(4728),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 18, 83, DateTimeKind.Utc).AddTicks(3648),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 18, 83, DateTimeKind.Utc).AddTicks(3651),
                             Email = "karla6524@example.com",
                             FullName = "Karla Chavez",
-                            Password = "$2a$11$m9Xwd4.i75APLKWj7eYfh.4nT2noIQ.v5RUH62eyrjoT/qFa81QZa",
-                            Status = 0,
+                            Password = "$2a$11$4AXjRfgLoNQZ2cYimg/aRu/NcCbJwMoN51w5LDr9On/L40gw.NFFK",
+                            Status = "Unverified",
                             UserName = "karla6524"
                         },
                         new
                         {
                             Id = -9,
-                            DateAdded = new DateTime(2024, 4, 16, 9, 31, 49, 100, DateTimeKind.Utc).AddTicks(245),
-                            DateUpdated = new DateTime(2024, 4, 16, 9, 31, 49, 100, DateTimeKind.Utc).AddTicks(250),
+                            DateAdded = new DateTime(2024, 4, 16, 16, 12, 18, 202, DateTimeKind.Utc).AddTicks(3793),
+                            DateUpdated = new DateTime(2024, 4, 16, 16, 12, 18, 202, DateTimeKind.Utc).AddTicks(3797),
                             Email = "mabel8750_@example.com",
                             FullName = "Mabel Ceballos",
-                            Password = "$2a$11$0.9MoZTHNFENbwkQSvUKEu8pYhiEjlskgOwRyX1p0icPGB/qA6ZsO",
-                            Status = 0,
+                            Password = "$2a$11$b9Yj0oFU037ZnFzkgzdNHe9WzMMTEcdesj0NnUMJWrjVWzy1cKF8W",
+                            Status = "Unverified",
                             UserName = "mabel8750_"
                         });
                 });

--- a/Lumina-Backend/Models/Account.cs
+++ b/Lumina-Backend/Models/Account.cs
@@ -1,18 +1,22 @@
-﻿namespace Lumina_Backend.Models;
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Lumina_Backend.Models;
 
 public class Account : BaseEntity
 {
     public virtual User User { get; set; }
 
     public int AccountNumber { get; set; }
+
+    [Column(TypeName = "varchar(24)")]
     public AccountType Type { get; set; }
     public decimal Balance { get; set; }
 
     public virtual ICollection<Transaction> Transactions { get; set; }
+}
 
-    public enum AccountType
-    {
-        Checking = 0,
-        Savings = 1
-    }
+public enum AccountType
+{
+    Savings,
+    Checking
 }

--- a/Lumina-Backend/Models/BaseEntity.cs
+++ b/Lumina-Backend/Models/BaseEntity.cs
@@ -1,9 +1,12 @@
-﻿namespace Lumina_Backend.Models;
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Lumina_Backend.Models;
 
 public class BaseEntity
 {
     public int Id { get; set; }
 
+    [Column(TypeName = "varchar(24)")]
     public EntityStatus Status { get; set; }
 
     public DateTime DateAdded { get; set; }
@@ -19,23 +22,21 @@ public class BaseEntity
 
         DateUpdated = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Utc);
     }
+}
 
-    public enum EntityStatus
-    {
-        Unverified = 0,
-        Verified = 1,
-        Active = 2,
-        Inactive = 3,
-        Frozen = 4,
-        Closed = 5,
-        Pending = 6,
-        Completed = 7,
-        Failed = 8,
-        Reversed = 9,
-        PendingReview = 10,
-        Approved = 11,
-        Rejected = 12,
-        Flagged = 13,
-        Ok = 14
-    }
+public enum EntityStatus
+{
+    Unverified,
+    Verified,
+    Active,
+    Inactive,
+    Frozen,
+    Closed,
+    Pending,
+    Completed,
+    Failed,
+    Reversed,
+    PendingReview,
+    Approved,
+    Rejected,
 }

--- a/Lumina-Backend/Models/Log.cs
+++ b/Lumina-Backend/Models/Log.cs
@@ -1,24 +1,37 @@
-﻿namespace Lumina_Backend.Models;
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
-public class Log : BaseEntity
+namespace Lumina_Backend.Models;
+
+public class Log
 {
+    [Key]
+    public int Id { get; set; }
     public virtual User User { get; set; }
 
+    [Column(TypeName = "varchar(24)")]
     public ActionType Action { get; set; }
 
-    /*
+    [Column(TypeName = "varchar(24)")]
+    public LogStatus Status { get; set; }
+
     public DateTime Timestamp { get; set; }
 
     public Log()
     {
         Timestamp = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Utc);
     }
-    */
+}
 
-    public enum ActionType
-    {
-        Login = 0,
-        Logout = 1,
-        Transaction = 2
-    }
+public enum ActionType
+{
+    Login,
+    Logout,
+    Transaction
+}
+
+public enum LogStatus
+{
+    Ok,
+    Flagged       
 }

--- a/Lumina-Backend/Models/Transaction.cs
+++ b/Lumina-Backend/Models/Transaction.cs
@@ -1,18 +1,21 @@
-﻿namespace Lumina_Backend.Models;
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Lumina_Backend.Models;
 
 public class Transaction : BaseEntity
 {
     public int AccountNumber { get; set; }
     public virtual Account Account { get; set; }
 
+    [Column(TypeName = "varchar(24)")]
     public TransactionType Type { get; set; }
     public decimal Amount { get; set; }
     public string? TransactionDescription { get; set; }
+}
 
-    public enum TransactionType
-    {
-        Deposit = 0,
-        Withdrawal = 1,
-        Transfer = 2
-    }
+public enum TransactionType
+{
+    Deposit,
+    Withdrawal,
+    Transfer
 }


### PR DESCRIPTION
…modelados para mejor parsing en el DB, se específico las columnas enum para que sean de tipo string usando DataAnnotations para varchar, de esta forma la reconversión entre enum y string para las tablas es automáticamente realizada por el DB, en las requests realizadas sin embargo se representa con el enum que corresponde, el string en base al enum es solo para legilibidad en el código de las APIs y las tablas del DB